### PR TITLE
Remove telescope projects

### DIFF
--- a/lua/plugins/user-practicalli.lua
+++ b/lua/plugins/user-practicalli.lua
@@ -236,9 +236,6 @@ return {
             desc = "Grep Word",
           },
 
-          -- Projects
-          ["<Leader>fp"] = { "<cmd>Telescope projects<cr>", desc = "Projects" },
-
           -- Editing
           ["zZ"] = { "<cmd>ZenMode<cr>", desc = " Zen mode" },
 


### PR DESCRIPTION
No longer works since a project plugin is no longer used.  Related discussion: https://clojurians.slack.com/archives/CJTRRQ857/p1718834288549289